### PR TITLE
Keyboard will hide now after attachment button pressed.

### DIFF
--- a/QMChatViewController/QMChatViewController.m
+++ b/QMChatViewController/QMChatViewController.m
@@ -358,6 +358,8 @@ static void * kChatKeyValueObservingContext = &kChatKeyValueObservingContext;
 
 - (void)didPressAccessoryButton:(UIButton *)sender {
     
+    [self.inputToolbar.contentView.textView resignFirstResponder];
+    
     UIActionSheet* actionSheet = [[UIActionSheet alloc] initWithTitle:nil
                                                              delegate:self
                                                     cancelButtonTitle:@"Cancel"


### PR DESCRIPTION
Fixed issue 173: https://github.com/QuickBlox/quickblox-ios-sdk/issues/173
