### PR TITLE
FIX. Fixed issue with autoscrolling to bottom (when set bottom inset).

### DIFF
--- a/QMChatViewController/QMChatViewController.m
+++ b/QMChatViewController/QMChatViewController.m
@@ -435,6 +435,20 @@ static void * kChatKeyValueObservingContext = &kChatKeyValueObservingContext;
     }
 }
 
+- (void)viewDidLayoutSubviews
+{
+  [super viewDidLayoutSubviews];
+  
+  [self.collectionView.collectionViewLayout invalidateLayout];
+  
+  if (self.automaticallyScrollsToMostRecentMessage) {
+    [self scrollToBottomAnimated:NO];
+    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:[QMCollectionViewFlowLayoutInvalidationContext context]];
+  }
+  
+  [self updateKeyboardTriggerPoint];
+}
+
 - (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     


### PR DESCRIPTION
Related to that behaviour:
https://coderwall.com/p/e-ajeq/uicollectionview-set-initial-contentoffset

Seems like the core issue (that the layout is not completed in viewWillAppear) can be fixed by making the necessary calls in viewDidLayoutSubviews instead.

I moved relevant stuff from the former to the latter, now they look like this:
- (void)viewDidLayoutSubviews
  {
  [super viewDidLayoutSubviews];
  
  [self.collectionView.collectionViewLayout invalidateLayout];
  
  if (self.automaticallyScrollsToMostRecentMessage) {
    [self scrollToBottomAnimated:NO];
    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:[QMCollectionViewFlowLayoutInvalidationContext context]];
  }
  
  [self updateKeyboardTriggerPoint];
  }
